### PR TITLE
add enable monthly and daily options to options param which ca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ const options = {
 
 ```
 
+**options.enable_monthly_options**
+
+```
+const options = {
+  enable_monthly_options: false
+};
+```
+
+**options.enable_daily_options**
+
+```
+const options = {
+  enable_daily_options: false
+};
+```
+
 ## Ref
 
 Added `ref` to the component now you can access state and functions using ref.

--- a/src/lib/cron-tab/daily.js
+++ b/src/lib/cron-tab/daily.js
@@ -53,17 +53,26 @@ export default class DailyCron extends Component {
     render() {
         const translateFn = this.props.translate;
         this.state.value = this.props.value;
+        let enable_daily_options = this.props.enable_daily_options;
+
+        let days = <div>
+                <span>{translateFn('Every')}</span>
+                <input disabled={!this.state.every} type="Number" maxLength="2" onChange={this.onDayChange} value={this.state.value[3].split('/')[1] ? this.state.value[3].split('/')[1] :''} />
+                <span>{translateFn('day(s)')}</span>
+            </div>;
+        let daily_options = enable_daily_options ? <div>
+            <div className="well well-small">
+                <input type="radio" onChange={(e) => {this.setState({ every:true }); this.props.onChange();}} value="1" name="DailyRadio" checked={this.state.every} />
+                {days}
+                </div>
+                <div className="well well-small">
+                    <input onChange={(e) => {this.setState({ every:false }); this.props.onChange(['0', this.state.value[1], this.state.value[2],'?','*', 'MON-FRI','*'])}} type="radio" value="2" name="DailyRadio" checked={!this.state.every}/>
+                    <span>{translateFn('Every week day')}</span>
+                </div>
+            </div> : days;
+
         return (<div className="tab-pane" >
-                    <div className="well well-small">
-                        <input type="radio" onChange={(e) => {this.setState({ every:true }); this.props.onChange();}} value="1" name="DailyRadio" checked={this.state.every} />
-                        <span>{translateFn('Every')}</span>
-                        <input disabled={!this.state.every} type="Number" maxLength="2" onChange={this.onDayChange} value={this.state.value[3].split('/')[1] ? this.state.value[3].split('/')[1] :''} />
-                        <span>{translateFn('day(s)')}</span>
-                    </div>
-                    <div className="well well-small">
-                        <input onChange={(e) => {this.setState({ every:false }); this.props.onChange(['0', this.state.value[1], this.state.value[2],'?','*', 'MON-FRI','*'])}} type="radio" value="2" name="DailyRadio" checked={!this.state.every}/>
-                        <span>{translateFn('Every week day')}</span>
-                    </div>
+                    {daily_options}
                     <span>{translateFn('Start time')}</span>
                     <Hour onChange={this.onAtHourChange} value={this.state.value[2]} />
                     <Minutes onChange={this.onAtMinuteChange} value={this.state.value[1]} />

--- a/src/lib/cron-tab/monthly.js
+++ b/src/lib/cron-tab/monthly.js
@@ -16,7 +16,7 @@ export default class MonthlyCron extends Component {
         this.onAtHourChange = this.onAtHourChange.bind(this);
         this.onAtMinuteChange = this.onAtMinuteChange.bind(this);
     }
-    
+
     componentWillMount() {
         this.state.value = this.props.value;
         if(this.state.value[3] === 'L'){
@@ -43,7 +43,7 @@ export default class MonthlyCron extends Component {
                     val[3] = ''
             } else {
                     val[3] = `L-${e.target.value}`;
-            } 
+            }
             this.props.onChange(val)
         }
     }
@@ -60,28 +60,35 @@ export default class MonthlyCron extends Component {
     render() {
         const translateFn = this.props.translate;
         this.state.value = this.props.value;
-        return (<div className="tab-pane" >
-                    <div className="well well-small">
-                        <input type="radio" onChange={(e) => {this.setState({every:e.target.value}); this.props.onChange(['0',this.state.value[1] === '*' ? '0' : this.state.value[1], this.state.value[2] === '*' ? '0': this.state.value[2],'1','1/1', '?','*'])}} value="1" name="MonthlyRadio" checked={this.state.every === "1" ? true : false} />
-                        {translateFn('Day')}
-                        <input readOnly={this.state.every !== "1"} type="number" value={this.state.value[3]} onChange={this.onDayChange}/>
-                        {translateFn('of every month(s)')}
-                    </div>
+        let enable_monthly_options = this.props.enable_monthly_options;
 
-                    <div className="well well-small">
-                        <input onChange={(e) => {this.setState({every:e.target.value}); this.props.onChange(['0',this.state.value[1] === '*' ? '0' : this.state.value[1], this.state.value[2] === '*' ? '0': this.state.value[2],'L','*', '?','*'])}} type="radio" value="2" name="DailyRadio" checked={this.state.every === "2" ? true : false}/>
-                        {translateFn('Last day of every month')}
-                    </div>
-                    <div className="well well-small">
-                        <input onChange={(e) => {this.setState({every:e.target.value}); this.props.onChange(['0',this.state.value[1] === '*' ? '0' : this.state.value[1], this.state.value[2] === '*' ? '0': this.state.value[2] ,'LW','*', '?','*'])}} type="radio" value="3" name="DailyRadio" checked={this.state.every === "3" ? true : false}/>
-                        {translateFn('On the last weekday of every month')}
-                    </div>
-                    <div className="well well-small">
-                        <input type="radio"  onChange={(e) => {this.setState({every:e.target.value});  this.props.onChange(['0',this.state.value[1] === '*' ? '0' : this.state.value[1], this.state.value[2] === '*' ? '0': this.state.value[2],`L-${1}`,'*', '?','*']) }} value="4" name="MonthlyRadio" checked={this.state.every === "4" ? true : false} />
-                       
-                        <input readOnly={this.state.every !== "4"} type="number" value={this.state.value[3].split('-')[1]} onChange={this.onLastDayChange}/>
-                        {translateFn('day(s) before the end of the month')}
-                    </div>
+        let monthly_days = <div>
+            {translateFn('Day')}
+            <input readOnly={this.state.every !== "1"} type="number" value={this.state.value[3]} onChange={this.onDayChange}/>
+            {translateFn('of every month(s)')}
+        </div>;
+        let monthly_options = enable_monthly_options ? <div>
+            <div className="well well-small">
+                <input type="radio" onChange={(e) => {this.setState({every:e.target.value}); this.props.onChange(['0',this.state.value[1] === '*' ? '0' : this.state.value[1], this.state.value[2] === '*' ? '0': this.state.value[2],'1','1/1', '?','*'])}} value="1" name="MonthlyRadio" checked={this.state.every === "1" ? true : false} />
+                {monthly_days}
+            </div>
+            <div className="well well-small">
+                <input onChange={(e) => {this.setState({every:e.target.value}); this.props.onChange(['0',this.state.value[1] === '*' ? '0' : this.state.value[1], this.state.value[2] === '*' ? '0': this.state.value[2],'L','*', '?','*'])}} type="radio" value="2" name="DailyRadio" checked={this.state.every === "2" ? true : false}/>
+                {translateFn('Last day of every month')}
+            </div>
+            <div className="well well-small">
+                <input onChange={(e) => {this.setState({every:e.target.value}); this.props.onChange(['0',this.state.value[1] === '*' ? '0' : this.state.value[1], this.state.value[2] === '*' ? '0': this.state.value[2] ,'LW','*', '?','*'])}} type="radio" value="3" name="DailyRadio" checked={this.state.every === "3" ? true : false}/>
+                {translateFn('On the last weekday of every month')}
+            </div>
+            <div className="well well-small">
+                <input type="radio"  onChange={(e) => {this.setState({every:e.target.value});  this.props.onChange(['0',this.state.value[1] === '*' ? '0' : this.state.value[1], this.state.value[2] === '*' ? '0': this.state.value[2],`L-${1}`,'*', '?','*']) }} value="4" name="MonthlyRadio" checked={this.state.every === "4" ? true : false} />
+                <input readOnly={this.state.every !== "4"} type="number" value={this.state.value[3].split('-')[1]} onChange={this.onLastDayChange}/>
+                {translateFn('day(s) before the end of the month')}
+            </div>
+        </div> : monthly_days;
+
+        return (<div className="tab-pane" >
+                    {monthly_options}
                     {translateFn('Start time')} 
                     <Hour onChange={this.onAtHourChange} value={this.state.value[2]} />
                     <Minutes onChange={this.onAtMinuteChange} value={this.state.value[1]} />

--- a/src/lib/cron.js
+++ b/src/lib/cron.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-direct-mutation-state */
 import React, { Component } from 'react';
 import cronstrue from 'cronstrue/i18n';
-import { metadata, loadHeaders } from './meta';
+import { metadata, loadHeaders, loadMonthlyOptions, loadDailyOptions } from './meta';
 import './cron-builder.css';
 
 export default class Cron extends Component {
@@ -10,6 +10,8 @@ export default class Cron extends Component {
         super(props);
         this.state = {
             headers: loadHeaders(this.props.options),
+            enable_monthly_options: loadMonthlyOptions(this.props.options),
+            enable_daily_options: loadDailyOptions(this.props.options),
             locale: this.props.locale ? this.props.locale : 'en'
         };
     }
@@ -120,7 +122,8 @@ export default class Cron extends Component {
             throw new Error('Value does not match any available headers.');
         }
         const CronComponent = selectedMetaData.component;
-        return <CronComponent translate={this.translate.bind(this)} value={this.state.value} onChange={this.onValueChange.bind(this)} />;
+        return <CronComponent translate={this.translate.bind(this)} value={this.state.value} onChange={this.onValueChange.bind(this)}
+                              enable_monthly_options={this.state.enable_monthly_options} enable_daily_options={this.state.enable_daily_options} />;
     }
 
     translate(key) {

--- a/src/lib/meta/index.js
+++ b/src/lib/meta/index.js
@@ -67,3 +67,35 @@ export const loadHeaders = (options) => {
     }
     return defaultTabs;
 };
+
+/**
+ * Validate and load enable_monthly_options
+ * @param {*} options
+ */
+export const loadMonthlyOptions = (options) => {
+    if(options) {
+        if(options.hasOwnProperty('enable_monthly_options')) {
+            if(typeof options.enable_monthly_options !== "boolean") {
+                throw new Error('enable_monthly_options must be true or false.');
+            }
+            return options.enable_monthly_options;
+        }
+    }
+    return true;
+};
+
+/**
+ * Validate and load enable_daily_options
+ * @param {*} options
+ */
+export const loadDailyOptions = (options) => {
+    if(options) {
+        if(options.hasOwnProperty('enable_daily_options')) {
+            if(typeof options.enable_daily_options !== "boolean") {
+                throw new Error('enable_daily_options must be true or false.');
+            }
+            return options.enable_daily_options;
+        }
+    }
+    return true;
+};


### PR DESCRIPTION
add enable monthly and daily options to options param which can be used to disable alternate monthly and daily selectors. This change allows users to configure the generator to only display the every ___ days/months option when on the respective tab. The motivation for this change is to give users the option to present a simpler menu for end users who may not need to leverage all the available options.