### PR TITLE
use explicit componentName attribute in metadata so that getting the …

### DIFF
--- a/src/lib/cron.js
+++ b/src/lib/cron.js
@@ -112,7 +112,7 @@ export default class Cron extends Component {
         if(metadata[index] === -1) {
             return;
         }
-        let selectedMetaData = metadata.find(data => data.component.name === (tab + 'Cron'))
+        let selectedMetaData = metadata.find(data => data.componentName === (tab + 'Cron'))
         if(!selectedMetaData) {
             selectedMetaData = metadata[index];
         }

--- a/src/lib/meta/index.js
+++ b/src/lib/meta/index.js
@@ -24,18 +24,23 @@ const defaultTabs = [HEADER_VALUES.MINUTES, HEADER_VALUES.HOURLY, HEADER_VALUES.
 
 export const metadata = [{
     component: Minutes,
+    componentName: "MinuteCron",
     initialCron: ['0','0/1','*','*','*','?','*']
 }, {
     component: Hourly,
+    componentName: "HourlyCron",
     initialCron: ['0','0','00','1/1','*','?','*']
 }, {
     component: Daily,
+    componentName: "DailyCron",
     initialCron: ['0','0','00','1/1','*','?','*']
 }, {
     component: Weekly,
+    componentName: "WeeklyCron",
     initialCron: ['0','0','00','?','*','*','*']
 }, {
     component: Monthly,
+    componentName: "MonthlyCron",
     initialCron: ['0','0','00','1','1/1','?','*']
 }];
 


### PR DESCRIPTION
…component can be done even if minifiers / tersers reduce or mangle the component names.