### PR TITLE
Add Custom tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Expects a method. Use this prop for localization support. `react-cron-generator`
 import { HEADER } from 'react-cron-generator';
 
 const options = {
-  headers: [HEADER.MONTHLY, HEADER.WEEKLY, HEADER.MINUTES, HEADER.HOURLY, HEADER.DAILY]
+  headers: [HEADER.MONTHLY, HEADER.WEEKLY, HEADER.MINUTES, HEADER.HOURLY, HEADER.DAILY, HEADER.CUSTOM]
 };
 
 ```

--- a/src/lib/cron-tab/custom.js
+++ b/src/lib/cron-tab/custom.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+
+export default class CustomCron extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+        };
+    }
+
+    onChange(e) {
+        this.props.onChange(e.target.value.replace(/,/g, '!').split(" "));
+    }
+
+    render() {
+        const translateFn = this.props.translate;
+        this.state.value = this.props.value;
+
+        let val = this.props.value.toString().replace(/,/g,' ').replace(/!/g, ',');
+
+        return (<div className="well">   
+               {translateFn('Expression')} <input type="text" onChange={this.onChange.bind(this)} value={val} />
+        </div>)
+    }
+}

--- a/src/lib/cron.js
+++ b/src/lib/cron.js
@@ -92,7 +92,7 @@ export default class Cron extends Component {
     }
 
     getVal() {
-        let val = cronstrue.toString(this.state.value.toString().replace(/,/g,' ').replace(/!/g, ','), { locale: this.state.locale })
+        let val = cronstrue.toString(this.state.value.toString().replace(/,/g,' ').replace(/!/g, ','), { throwExceptionOnParseError: false, locale: this.state.locale })
         if(val.search('undefined') === -1) {
             return val;
         }

--- a/src/lib/localization/translation.json
+++ b/src/lib/localization/translation.json
@@ -22,5 +22,7 @@
     "Hourly": "Hourly",
     "Daily": "Daily",
     "Weekly": "Weekly",
-    "Monthly": "Monthly"
+    "Monthly": "Monthly",
+    "Custom": "Custom",
+    "Expression": "Expression"
 }

--- a/src/lib/meta/index.js
+++ b/src/lib/meta/index.js
@@ -3,13 +3,15 @@ import Daily from '../cron-tab/daily';
 import Hourly from '../cron-tab/hourly';
 import Weekly from '../cron-tab/weekly';
 import Monthly from '../cron-tab/monthly';
+import Custom from '../cron-tab/custom';
 
 export const HEADER = {
     MINUTES: 'MINUTES',
     HOURLY: 'HOURLY',
     DAILY: 'DAILY',
     WEEKLY: 'WEEKLY',
-    MONTHLY: 'MONTHLY'
+    MONTHLY: 'MONTHLY',
+    CUSTOM: 'CUSTOM'
 };
 
 const HEADER_VALUES = {
@@ -17,10 +19,11 @@ const HEADER_VALUES = {
     HOURLY: 'Hourly',
     DAILY: 'Daily',
     WEEKLY: 'Weekly',
-    MONTHLY: 'Monthly'
+    MONTHLY: 'Monthly',
+    CUSTOM: 'Custom'
 };
 
-const defaultTabs = [HEADER_VALUES.MINUTES, HEADER_VALUES.HOURLY, HEADER_VALUES.DAILY, HEADER_VALUES.WEEKLY, HEADER_VALUES.MONTHLY];
+const defaultTabs = [HEADER_VALUES.MINUTES, HEADER_VALUES.HOURLY, HEADER_VALUES.DAILY, HEADER_VALUES.WEEKLY, HEADER_VALUES.MONTHLY, HEADER_VALUES.CUSTOM];
 
 export const metadata = [{
     component: Minutes,
@@ -37,6 +40,9 @@ export const metadata = [{
 }, {
     component: Monthly,
     initialCron: ['0','0','00','1','1/1','?','*']
+}, {
+    component: Custom,
+    initialCron: ['*','*','*','*','*','*','*']
 }];
 
 const validateHeaders = (headers) => {


### PR DESCRIPTION
Thanks for making this!

I know a similar pull request was previously rejected, but having a Custom tab is necessary in our use case in order to provide flexibility. For example, there is no way to do "At 0 minutes past the hour, every 6 hours, starting at 04:00 AM" (0 0 4/6 * * * *) on any tab, and I could give more examples.

I think this is a helpful feature, which could be left off by default if you felt strongly about it.