### PR TITLE
Stop relying on class name when determining which tab component to display

### DIFF
--- a/src/lib/cron.js
+++ b/src/lib/cron.js
@@ -112,7 +112,7 @@ export default class Cron extends Component {
         if(metadata[index] === -1) {
             return;
         }
-        let selectedMetaData = metadata.find(data => data.component.name === (tab + 'Cron'))
+        let selectedMetaData = metadata.find(data => data.name === tab);
         if(!selectedMetaData) {
             selectedMetaData = metadata[index];
         }

--- a/src/lib/meta/index.js
+++ b/src/lib/meta/index.js
@@ -27,21 +27,27 @@ const defaultTabs = [HEADER_VALUES.MINUTES, HEADER_VALUES.HOURLY, HEADER_VALUES.
 
 export const metadata = [{
     component: Minutes,
+    name: HEADER_VALUES.MINUTES,
     initialCron: ['0','0/1','*','*','*','?','*']
 }, {
     component: Hourly,
+    name: HEADER_VALUES.HOURLY,
     initialCron: ['0','0','00','1/1','*','?','*']
 }, {
     component: Daily,
+    name: HEADER_VALUES.DAILY,
     initialCron: ['0','0','00','1/1','*','?','*']
 }, {
     component: Weekly,
+    name: HEADER_VALUES.WEEKLY,
     initialCron: ['0','0','00','?','*','*','*']
 }, {
     component: Monthly,
+    name: HEADER_VALUES.MONTHLY,
     initialCron: ['0','0','00','1','1/1','?','*']
 }, {
     component: Custom,
+    name: HEADER_VALUES.CUSTOM,
     initialCron: ['*','*','*','*','*','*','*']
 }];
 


### PR DESCRIPTION
This pull request introduces a name attribute in the tabs metadata so the component class name doesn't need to be used. It fixes tab display issues when the library is included in an obfuscated project build.

#24 addresses the same issue but doesn't support the new custom tab.