### PR TITLE
Update package.json to support babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-cron-generator",
   "version": "2.0.12",
   "description": "Simple react component to generate cron expression",
+  "type": "module",
   "keywords": [
     "React cron generator",
     "cron builder",


### PR DESCRIPTION
Currently my project is coming up with an error concerning not recognizing this package as a module: "cannot import import { jsxs , jsx } from react/jsx-runtime". The way that I fixed this problem was by declaring this package as a module in the package.json file. After some research I saw this problem was also found in other packages like jest which is supported by babel.