### PR TITLE
CronProp and cronsture importable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ const options = {
 
 ```
 
+## Importables
+
+  Cron - The react Cron component. - Default  
+  CronProp - Cron component types.  
+  cronsture - Cronsture/i18 - [cronstrue](https://www.npmjs.com/package/cronstrue)  
+
 
 ## Release notes 2.x.x
 1. Build Procedure updated

--- a/src/lib/cron.tsx
+++ b/src/lib/cron.tsx
@@ -3,7 +3,7 @@ import cronstrue from 'cronstrue/i18n';
 import { metadata, loadHeaders, HeaderKeyType, HeaderValType } from './meta';
 import translations from "../lib/localization/translation.json"
 import './cron-builder.css';
-interface CronProp {
+export interface CronProp {
     value?: string
     onChange(val: string, text: string): void
     showResultText: boolean

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
-import Cron from './cron';
+import Cron, { CronProp } from "./cron";
 import { HEADER } from './meta';
 
 export { HEADER };
+export type { CronProp };
 export default Cron;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,7 @@
 import Cron, { CronProp } from "./cron";
 import { HEADER } from './meta';
+import cronstrue from "cronstrue/i18n";
 
-export { HEADER };
+export { HEADER, cronstrue };
 export type { CronProp };
 export default Cron;


### PR DESCRIPTION
Make CronProp type importable.

Contributes to: #77 