### PR TITLE
Move `onClick` as `onChange` to input fields

### DIFF
--- a/src/lib/cron-builder.css
+++ b/src/lib/cron-builder.css
@@ -93,6 +93,7 @@
   font-size: 14px;
 }
 .cron_builder .well {
+  display: block;
   min-height: 20px;
   padding: 19px;
   margin-bottom: 20px;
@@ -127,9 +128,9 @@
   min-height: auto !important;
 }
 .cron_builder {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
-    'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }
 .cron_builder .cursor_pointer {
   cursor: pointer;

--- a/src/lib/cron-tab/daily.tsx
+++ b/src/lib/cron-tab/daily.tsx
@@ -77,12 +77,13 @@ const DailyCron: FunctionComponent<DailyCronProp> = (props) => {
   const translateFn = props.translate;
   return (
     <div className="tab-pane">
-      <div className="well well-small cursor_pointer" onClick={onClickDailyRadio}>
+      <label className="well well-small cursor_pointer">
         <input
           type="radio"
           value="1"
           name="DailyRadio"
           checked={state.every}
+          onChange={onClickDailyRadio}
           disabled={props.disabled}
         />
         <span>{translateFn('Every')}</span>
@@ -95,17 +96,18 @@ const DailyCron: FunctionComponent<DailyCronProp> = (props) => {
           value={props.value[3].split('/')[1] ? props.value[3].split('/')[1] : ''}
         />
         <span>{translateFn('day(s)')}</span>
-      </div>
-      <div className="well well-small cursor_pointer" onClick={onClickEveryWeekDay}>
+      </label>
+      <label className="well well-small cursor_pointer">
         <input
           type="radio"
           value="2"
           name="EveryWeekDay"
           checked={!state.every}
+          onChange={onClickEveryWeekDay}
           disabled={props.disabled}
         />
         <span>{translateFn('Every week day')}</span>
-      </div>
+      </label>
       <span>{translateFn('Start time')}</span>
       <Hour onChange={onAtHourChange} value={props.value[2]} disabled={props.disabled} />
       <Minutes onChange={onAtMinuteChange} value={props.value[1]} disabled={props.disabled} />

--- a/src/lib/cron-tab/hourly.tsx
+++ b/src/lib/cron-tab/hourly.tsx
@@ -85,11 +85,12 @@ const HourlyCron: FunctionComponent<HourlyCronProp> = (props) => {
   return (
     <div className="tab-content">
       <div className="tab-pane active">
-        <div className="well well-small cursor_pointer" onClick={onClickEveryHourMinute}>
+        <label className="well well-small cursor_pointer">
           <input
             name="EveryHourMinute"
             type="radio"
             checked={state.every}
+            onChange={onClickEveryHourMinute}
             disabled={props.disabled}
           />
           <span>{translateFn('Every')} </span>
@@ -109,18 +110,19 @@ const HourlyCron: FunctionComponent<HourlyCronProp> = (props) => {
             value={props.value[1]}
           />
           <span>{translateFn('minute(s)')}</span>
-        </div>
-        <div className="well well-small cursor_pointer" onClick={onClickEverySpecificHour}>
+        </label>
+        <label className="well well-small cursor_pointer">
           <input
             name="EverySpecificHour"
             type="radio"
             checked={!state.every}
+            onChange={onClickEverySpecificHour}
             disabled={props.disabled}
           />
           <span>{translateFn('At')}</span>
           <Hour disabled={props.disabled} onChange={onAtHourChange} value={props.value[2]} />
           <Minutes disabled={props.disabled} onChange={onAtMinuteChange} value={props.value[1]} />
-        </div>
+        </label>
       </div>
     </div>
   );

--- a/src/lib/cron-tab/monthly.tsx
+++ b/src/lib/cron-tab/monthly.tsx
@@ -187,12 +187,13 @@ const MonthlyCron: FunctionComponent<MonthlyCronProp> = (props) => {
   const translateFn = props.translate;
   return (
     <div className="tab-pane">
-      <div className="well well-small cursor_pointer" onClick={() => onClickMonthlyOnceRadio()}>
+      <label className="well well-small cursor_pointer">
         <input
           type="radio"
           value="1"
           name="MonthlyOnceRadio"
           checked={state.every === '1' ? true : false}
+          onChange={() => onClickMonthlyOnceRadio()}
           disabled={props.disabled}
         />
         {translateFn('Day')}
@@ -204,36 +205,36 @@ const MonthlyCron: FunctionComponent<MonthlyCronProp> = (props) => {
           disabled={props.disabled}
         />
         {translateFn('of every month(s)')}
-      </div>
-      <div className="well well-small cursor_pointer" onClick={() => onClickLastDayOfEveryMonth()}>
+      </label>
+      <label className="well well-small cursor_pointer">
         <input
           type="radio"
           value="2"
           name="LastDayOfEveryMonth"
           checked={state.every === '2' ? true : false}
+          onChange={() => onClickLastDayOfEveryMonth()}
           disabled={props.disabled}
         />
         {translateFn('Last day of every month')}
-      </div>
-      <div
-        className="well well-small cursor_pointer"
-        onClick={() => onClickLastWeekdayOfEveryMonth()}
-      >
+      </label>
+      <label className="well well-small cursor_pointer">
         <input
           type="radio"
           value="3"
           name="LastWeekdayOfEveryMonth"
           checked={state.every === '3' ? true : false}
+          onChange={() => onClickLastWeekdayOfEveryMonth()}
           disabled={props.disabled}
         />
         {translateFn('On the last weekday of every month')}
-      </div>
-      <div className="well well-small cursor_pointer" onClick={() => onClickDaysBeforeEndOfMonth()}>
+      </label>
+      <label className="well well-small cursor_pointer">
         <input
           type="radio"
           value="4"
           name="DaysBeforeEndOfMonth"
           checked={state.every === '4' ? true : false}
+          onChange={() => onClickDaysBeforeEndOfMonth()}
           disabled={props.disabled}
         />
 
@@ -249,13 +250,14 @@ const MonthlyCron: FunctionComponent<MonthlyCronProp> = (props) => {
           disabled={props.disabled}
         />
         {translateFn('day(s) before the end of the month')}
-      </div>
-      <div className="well well-small cursor_pointer" onClick={() => onClickMonthlyMultipleRadio()}>
+      </label>
+      <label className="well well-small cursor_pointer">
         <input
           type="radio"
           value="5"
           name="MonthlyMultipleRadio"
           checked={state.every === '5' ? true : false}
+          onChange={() => onClickMonthlyMultipleRadio()}
           disabled={props.disabled}
         />
         <DaySelect
@@ -265,7 +267,7 @@ const MonthlyCron: FunctionComponent<MonthlyCronProp> = (props) => {
           multi
         />
         {translateFn('Days of every month')}
-      </div>
+      </label>
 
       {translateFn('Start time')}
       <Hour onChange={onAtHourChange} value={props.value[2]} disabled={props.disabled} />


### PR DESCRIPTION
### 💬 Description

- Move the event handler to the input element. This allows the event to be trigggered when the input change. 
- Wrap the input elements in `label`, so the event handlers are triggered even when clicked anywhere inside it, which contains multiple input fields. 
- Finally to keep the styling same, add `display: block` to `well` class. The `well` class is applied to `div` (which is already a block element) and (now) to `label`, which are `inline` elements by default.

### 🔗 Github Issues Link

Fixes https://github.com/sojinantony01/react-cron-generator/issues/91

### 🌉 Screenshots
